### PR TITLE
Remove forceful foreground color on buttons

### DIFF
--- a/PhotoAlbumViewer/CoreImageViewer.swift
+++ b/PhotoAlbumViewer/CoreImageViewer.swift
@@ -199,7 +199,6 @@ class CoreImageViewer: NSViewController, NSWindowDelegate {
         button.attributedTitle = NSAttributedString(
             string: button.title,
             attributes: [
-                .foregroundColor: NSColor.white,
                 .font: NSFont.systemFont(ofSize: NSFont.systemFontSize)
             ]
         )


### PR DESCRIPTION
Removed .foregroundColor attribute, button text is black when system appearance is set to "Light" and white when its set to "Dark" mode.